### PR TITLE
Fix Ubuntu installation issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ end
 
 def run_command(cmd)
   puts "running #{cmd}"
-  `#{cmd}`
+  system cmd
 end
 
 def macos?

--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,9 @@ then
   echo "  - silver searcher"
   echo "  - zsh"
   echo "  - vim (vim-gnome | macvim)"
-  echo "  - google-chrome"
+  echo "  - google-chrome (mac)"
   echo "  - iterm2 (mac)"
-  echo "  - atom"
+  echo "  - atom (mac)"
 
   git clone --depth=10 https://github.com/campuscode/cc_dotfiles.git "$HOME/.cc_dotfiles"
   cd "$HOME/.cc_dotfiles"

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -11,5 +11,4 @@ sudo apt-get install tmux
 sudo apt-get install dconf-cli
 sudo apt-get install vim-gnome
 git clone https://github.com/Anthony25/gnome-terminal-colors-solarized.git
-cd gnome-terminal-colors-solarized/
-cd ~
+~/.cc_dotfiles/gnome-terminal-colors-solarized/install.sh 

--- a/zsh/themes/peepcode.theme
+++ b/zsh/themes/peepcode.theme
@@ -23,7 +23,7 @@ git_mode() {
 
 git_dirty() {
   if [[ "$repo_path" != '.' && `git ls-files -m` != "" ]]; then
-    echo " %{$fg_bold[grey]%}✗%{$reset_color%}"
+    echo " %{$fg_bold[magenta]%}✗%{$reset_color%}"
   fi
 }
 
@@ -42,7 +42,7 @@ git_prompt() {
   local cb=$(current_branch)
   if [ -n "$cb" ]; then
     local repo_path=$(git_repo_path)
-    echo " %{$fg_bold[grey]%}$cb %{$fg[white]%}$(git_commit_id)%{$reset_color%}$(git_mode)$(git_dirty)"
+    echo " %{$fg_bold[magenta]%}$cb %{$fg[white]%}$(git_commit_id)%{$reset_color%}$(git_mode)$(git_dirty)"
   fi
 }
 

--- a/zsh/themes/peepcode.theme
+++ b/zsh/themes/peepcode.theme
@@ -23,7 +23,7 @@ git_mode() {
 
 git_dirty() {
   if [[ "$repo_path" != '.' && `git ls-files -m` != "" ]]; then
-    echo " %{$fg_bold[magenta]%}✗%{$reset_color%}"
+    echo " %{$fg_bold[yellow]%}✗%{$reset_color%}"
   fi
 }
 
@@ -42,7 +42,7 @@ git_prompt() {
   local cb=$(current_branch)
   if [ -n "$cb" ]; then
     local repo_path=$(git_repo_path)
-    echo " %{$fg_bold[magenta]%}$cb %{$fg[white]%}$(git_commit_id)%{$reset_color%}$(git_mode)$(git_dirty)"
+    echo " %{$fg_bold[yellow]%}$cb %{$fg[white]%}$(git_commit_id)%{$reset_color%}$(git_mode)$(git_dirty)"
   fi
 }
 


### PR DESCRIPTION
- Change method 'run_command' to run commands by Kernel::system
  it improves viewing of commands output (needed to run solarized install.sh)
- Add command to install Solarized Colors
- Change color of git prompt, to improve branch name view