### PR TITLE
Add the option for interactive comments

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -1,6 +1,5 @@
 setopt promptsubst
 
-
 # load our own completion functions
 fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
 
@@ -68,3 +67,5 @@ TERM=screen-256color
 
 # Your secrets env var
 [[ -f ~/.secrets ]] && source ~/.secrets
+
+setopt interactivecomments


### PR DESCRIPTION
Add the option for interactive comments, like we use in bash `$ command #comment`
What are the comments so important for us?

With comments, the `CTRL+R` (Reverse search) becomes more easy to find the specific command.