### PR TITLE
Remove atalho do git stash drop

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -76,7 +76,6 @@
   ss = stash                        # stash changes
   sl = stash list                   # list stashes
   sa = stash apply                  # apply stash (restore changes)
-  #sd = stash drop                   # drop stashes (destory changes)
 
   # status
   s = status                        # status

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -76,7 +76,7 @@
   ss = stash                        # stash changes
   sl = stash list                   # list stashes
   sa = stash apply                  # apply stash (restore changes)
-  sd = stash drop                   # drop stashes (destory changes)
+  #sd = stash drop                   # drop stashes (destory changes)
 
   # status
   s = status                        # status


### PR DESCRIPTION
O atalho `git stash drop` é extremamente contra-produtivo, já que o `git status` é `git s` e a letra D fica ao lado da S, devido a ser a terceira vez que deleto uma stash importante (E acho mais engraçado o fato de só digitar `sd` quando eu gero uma `stash`, conspiração?), proponho a remoção do atalho do `gitconfig`