### PR TITLE
Fix ubuntu and windows installation process

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ then
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
       curl -sSL https://get.rvm.io | bash -s stable --ruby
       sudo usermod -a -G rvm `whoami`
+      sudo apt-get install ruby
       ;;
     Darwin )
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
@@ -25,8 +26,9 @@ then
       sudo usermod -a -G rvm `whoami`
       ;;
     CYGWIN* | MSYS*)
-      echo 'You are using a Windows which is not recommended to use with out dotfiles.'
-      echo 'Abort installation'
+      echo 'You are using a Windows machine which is not recommended to use with our' \
+           ' dotfiles.'
+      echo 'You can clone our repository and install it manually.'
       return
       ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -13,9 +13,16 @@ then
   echo "  - atom (mac)"
 
   case "$(uname -s)" in
-    Linux | Darwin)
+    Linux)
+      sudo apt-get install -y git curl gnupg build-essential
       gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-      \curl -sSL https://get.rvm.io | bash -s stable
+      curl -sSL https://get.rvm.io | bash -s stable --ruby
+      sudo usermod -a -G rvm `whoami`
+      ;;
+    Darwin )
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+      curl -sSL https://get.rvm.io | bash -s stable --ruby
+      sudo usermod -a -G rvm `whoami`
       ;;
     CYGWIN* | MSYS*)
       echo 'You are using a Windows which is not recommended to use with out dotfiles.'
@@ -24,6 +31,7 @@ then
       ;;
     *)
       echo 'Operational system not recognized, aborting installation'
+      return
       ;;
   esac
   git clone --depth=10 https://github.com/campuscode/cc_dotfiles.git "$HOME/.cc_dotfiles"

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -10,3 +10,8 @@ sudo apt-get install -y silversearcher-ag \
  vim-gnome
 git clone https://github.com/Anthony25/gnome-terminal-colors-solarized.git
 ~/.cc_dotfiles/gnome-terminal-colors-solarized/install.sh
+sudo apt-get purge ruby
+echo 'Change your terminal window to Run command as login shell and restart'
+echo 'You can find more information about this on' \
+     'https://github.com/rvm/ubuntu_rvm'
+


### PR DESCRIPTION
## Motivation

If you install RVM it doen't make ruby available until you do `rvm install RUBY_VERSION` on Mac OS this is not a problem because it comes with Ruby. But on Linux machines `rake install` fails.

To correct this problem i made sure to install ruby via `apt-get install ruby` and purge it after installation.

## Comments
Changed rvm install to install the latest stable version of Ruby