### PR TITLE
Remove duplication from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,8 +64,8 @@ def install_fonts
   puts "======================================================"
   puts "Installing patched fonts for Powerline/Lightline."
   puts "======================================================"
-  run_command %{ cp -f $HOME/.cc_dotfiles/fonts/* $HOME/Library/Fonts } if RUBY_PLATFORM.downcase.include?("darwin")
-  run_command %{ mkdir -p ~/.fonts && cp ~/.cc_dotfiles/fonts/* ~/.fonts && fc-cache -vf ~/.fonts } if RUBY_PLATFORM.downcase.include?("linux")
+  run_command %{ cp -f $HOME/.cc_dotfiles/fonts/* $HOME/Library/Fonts } if macos?
+  run_command %{ mkdir -p ~/.fonts && cp ~/.cc_dotfiles/fonts/* ~/.fonts && fc-cache -vf ~/.fonts } if linux?
   puts
 end
 


### PR DESCRIPTION
Estava olhando o Rakefile e percebi uma duplicação de código no momento da instalação de fontes. Já tínhamos métodos para encontrar o sistema operacional, então só modifiquei o `install_fonts` para utilizá-los.